### PR TITLE
Allow passing body as array for json

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -4,10 +4,8 @@ namespace NetRivet\WordPress\Http;
 
 use WP_Http;
 
-
 class Request implements RequestInterface
 {
-
     /**
      * @var ResponseFactory
      */

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -4,7 +4,6 @@ namespace NetRivet\WordPress\Http;
 
 use WP_Http;
 
-
 interface RequestInterface
 {
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -2,17 +2,15 @@
 
 namespace NetRivet\WordPress\Http;
 
-
 class Response implements ResponseInterface
 {
-
     /**
      * @var int
      */
     protected $statusCode;
 
     /**
-     * @param string  $body
+     * @param string|array $body
      * @param integer $statusCode
      * @throws \InvalidArgumentException
      */
@@ -20,6 +18,10 @@ class Response implements ResponseInterface
     {
         if (! $this->statusCodeValid($statusCode)) {
             throw new \InvalidArgumentException('Invalid status code');
+        }
+
+        if (is_array($body)) {
+            $body = json_encode($body);
         }
 
         $this->body = $body;

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -4,10 +4,8 @@ namespace NetRivet\WordPress\Http;
 
 use WP_Error;
 
-
 class ResponseFactory
 {
-
     /**
      * Create a Response object from mixed WP_Http::request return values
      *

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -2,10 +2,8 @@
 
 namespace NetRivet\WordPress\Http;
 
-
 interface ResponseInterface
 {
-
     /**
      * Gets the response status code
      *

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,7 +2,6 @@
 
 namespace NetRivet\WordPress\Http;
 
-
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -20,14 +19,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-
     public function setUp()
     {
         $this->wpHttp  = $this->prophesize('WP_Http');
         $this->factory = $this->prophesize('NetRivet\WordPress\Http\ResponseFactory');
         $this->request = new Request($this->factory->reveal(), $this->wpHttp->reveal());
     }
-
 
     public function testGetPassesArgsOnToWordpressClass()
     {
@@ -36,14 +33,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->request->get('http://foo.com', ['bar']);
     }
 
-
     public function testPostPassesArgsOnToWordpressClass()
     {
         $this->wpHttp->post('http://foo.com', ['bar'])->shouldBeCalled();
 
         $this->request->post('http://foo.com', ['bar']);
     }
-
 
     public function testPostJsonSetsHeadersAndJsonEncodesDataParam()
     {
@@ -57,7 +52,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->request->postJson('uri', ['foo' => 'bar']);
     }
-
 
     public function testReturnsResultOfPassingWpDataToFactoryCreate()
     {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -2,10 +2,8 @@
 
 namespace NetRivet\WordPress\Http;
 
-
 class ResponseFactoryTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var ResponseFactory
      */
@@ -17,14 +15,12 @@ class ResponseFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory = new ResponseFactory();
     }
 
-
     public function testUnexpectedInputCreates500Response()
     {
         $response = $this->factory->create(111);
 
         $this->assertSame(500, $response->getStatusCode());
     }
-
 
     public function testArrayMissingResponseCodeCreates500Response()
     {
@@ -33,7 +29,6 @@ class ResponseFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(500, $response->getStatusCode());
     }
 
-
     public function testNormalWordpressArrayConvertedCorrectly()
     {
         $response = $this->factory->create(['body' => 'the body', 'response' => ['code' => '200']]);
@@ -41,7 +36,6 @@ class ResponseFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('the body', $response->getBody());
     }
-
 
     public function testReturns500ResponseWithErrorsWhenInputIsWordpressErrorObject()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -21,14 +21,12 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         new Response('', 999);
     }
 
-
     public function testReturnsStatusCode()
     {
         $response = new Response('', 201);
 
         $this->assertSame(201, $response->getStatusCode());
     }
-
 
     public function testGetBodyReturnsBody()
     {
@@ -46,7 +44,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->json();
     }
 
-
     public function testJsonReturnsJsonDecodedBody()
     {
         $response = new Response(json_encode(['foo' => 'bar']));
@@ -55,20 +52,17 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['foo' => 'bar'], $json);
     }
 
-
     public function testJsonReturnsEmptyArrayForEmptyBody()
     {
         $response = new Response();
         $this->assertSame([], $response->json());
     }
 
-
     public function testJsonStringIsJson()
     {
         $response = new Response('["foo"]');
         $this->assertTrue($response->isJson());
     }
-
 
     public function testNonJsonStringIsNotJson()
     {
@@ -84,5 +78,13 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response($encoded);
 
         $this->assertEquals(['foo' => 'bar'], $response->json());
+    }
+
+    public function testPassingArrayForBodyMakesResponseJson()
+    {
+        $response = new Response(['foo' => 'bar']);
+
+        $this->assertTrue($response->isJson());
+        $this->assertSame(['foo' => 'bar'], $response->json());
     }
 }


### PR DESCRIPTION
This is a super frequent usage of a response object, to setup a JSON api response, and Symfony and Laravel does the same, so seemed good.

Also, fixed some PSR-2 things while I was in there.
