### PR TITLE
Allow passing extra params like timeout to Request::postJson()

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -18,7 +18,7 @@ class Request implements RequestInterface
 
     /**
      * @param ResponseFactory $factory
-     * @param WP_Http         $wpHttp
+     * @param WP_Http $wpHttp
      */
     public function __construct(ResponseFactory $factory = null, WP_Http $wpHttp = null)
     {
@@ -45,15 +45,15 @@ class Request implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function postJson($uri, array $data)
+    public function postJson($uri, array $body, array $params = [])
     {
-        $data = $this->wpHttp->post($uri, [
+        $data = $this->wpHttp->post($uri, array_merge($params, [
             'headers' => [
                 'Accept'       => 'application/json',
                 'Content-Type' => 'application/json',
             ],
-            'body' => json_encode($data),
-        ]);
+            'body' => json_encode($body),
+        ]));
 
         return $this->factory->create($data);
     }

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -9,37 +9,38 @@ interface RequestInterface
     /**
      * Send an http GET request
      *
-     * @param  string $uri
-     * @param  array  $params
-     * @return NetRivet\WordPress\Http\ResponseInterface
+     * @param string $uri
+     * @param array $params
+     * @return ResponseInterface
      */
     public function get($uri, array $params = []);
 
     /**
      * Send an http POST request
      *
-     * @param  string $uri
-     * @param  array  $params
-     * @return NetRivet\WordPress\Http\ResponseInterface
+     * @param string $uri
+     * @param array $params
+     * @return ResponseInterface
      */
     public function post($uri, array $params = []);
 
     /**
      * Send a json-encoded http POST request
      *
-     * @param  string $uri
-     * @param  array  $data
-     * @return NetRivet\WordPress\Http\ResponseInterface
+     * @param string $uri
+     * @param array $body
+     * @param array $params
+     * @return ResponseInterface
      */
-    public function postJson($uri, array $data);
+    public function postJson($uri, array $body, array $params = []);
 
     /**
      * Send an http request
      *
-     * @param  string $method
-     * @param  string $uri
-     * @param  array  $params
-     * @return NetRivet\WordPress\Http\ResponseInterface
+     * @param string $method
+     * @param string $uri
+     * @param array $params
+     * @return ResponseInterface
      */
     public function request($method, $uri, array $params = []);
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -61,4 +61,18 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->request->get('uri');
     }
+
+    public function testPostJsonAllowsPassingExtraParamsToWpHttpPost()
+    {
+        $this->wpHttp->post('uri', [
+            'headers' => [
+                'Accept'       => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'body' => json_encode(['foo' => 'bar']),
+            'jim' => 'jam',
+        ])->shouldBeCalled();
+
+        $this->request->postJson('uri', ['foo' => 'bar'], ['jim' => 'jam']);
+    }
 }


### PR DESCRIPTION
This gives more flexibility to take advantage of the WordPress HTTP api, to pass in things like timeout values.  Also cleans up some docblock stuff to be simpler and more in line with our style.
